### PR TITLE
Calendario 2024 1C

### DIFF
--- a/calendario.md
+++ b/calendario.md
@@ -2,8 +2,10 @@ Calendario
 ==========
 
 La materia será dictada en 32 clases a lo largo de 16 semanas.
+
 Cada clase estará dividida en una parte teórica y una práctica, de 1:30 hs cada una.
-Las clases teóricas se dictarán los días lunes y viernes de 17:30 a 19:00 hs y las clases prácticas, los mismos días en el horario de 19:00 a 20:30 hs.
+
+Las clases teóricas se dictarán los días lunes y jueves de 17:30 a 19:00 hs y las clases prácticas, los mismos días en el horario de 19:00 a 20:30 hs.
 
 Además, contamos con un [calendario detallado]({{site.data.cuatrimestre.calendario_detallado}}) de las clases para descargar.
 


### PR DESCRIPTION
Actualizo la página del calendario ya que estaba puesto que había clase los viernes y separo con punto y aparte para que tenga mejor legibilidad.