### PR TITLE
Fix link a mail y github docente

### DIFF
--- a/_includes/docentes.html
+++ b/_includes/docentes.html
@@ -1,6 +1,6 @@
 <div class="row justify-content-center">
   <div class="col-4 d-none d-sm-block">
-    <h2 class="text-center">{{ include.titulo }}</h2>
+    <h2 class="text-center mt-0 pt-0">{{ include.titulo }}</h2>
   </div>
 </div>
 


### PR DESCRIPTION
Arreglo el problema de que los iconos con los links al mail y github del docente no se podian clickear.
El problema era que el h2 tenia un margin top y un padding top por defecto que se compensaban pero hacia que el contenedor del h2 se posicione por encima de los links, seteando el margin top y el padding top en 0 se mantiene la misma estructura pero se soluciona el problema de superposición.